### PR TITLE
Fixup conda env setup

### DIFF
--- a/caduceus_env.yml
+++ b/caduceus_env.yml
@@ -25,7 +25,7 @@ dependencies:
       - genomic-benchmarks==0.0.9
       - git-lfs==1.6
       - h5py==3.10.0
-      - huggingface-hub==0.19.4
+      - huggingface-hub==0.24.7
       - hydra-core==1.3.2
       - ipdb==0.13.13
       - matplotlib==3.7.4

--- a/caduceus_env.yml
+++ b/caduceus_env.yml
@@ -8,6 +8,13 @@ dependencies:
   - cuda-nvcc=11.7.99
   - pip=23.3.1
   - python=3.8
+  - pytorch=2.2.0
+  - torchaudio=2.2.0
+  - torchaudio=2.2.0
+  - torchdata=0.7.1
+  - torchmetrics=1.2.1
+  - torchtext=0.17.0
+  - torchvision=0.17.0
   - pytorch-cuda=12.1
   - pip:
       - biopython==1.81
@@ -34,12 +41,6 @@ dependencies:
       - seaborn==0.13.2
       - scikit-learn==1.3.2
       - timm==0.9.16
-      - torch==2.2.0
-      - torchaudio==2.2.0
-      - torchdata==0.7.1
-      - torchmetrics==1.2.1
-      - torchtext==0.17.0
-      - torchvision==0.17.0
       - tqdm==4.66.1
       - transformers==4.38.1
       - triton==2.2.0


### PR DESCRIPTION
👋 thanks for open-sourcing 🙇 

The provided conda environment fails (tested on Colab VM). There are 2 problems:
 * `flash-attn`, `causal-conv1d` and `mamba-ssm`, all import `torch` during the build (e.g. [here](https://github.com/state-spaces/mamba/blob/74729d0f6d9c2096407eda5562393ab70960a3f6/setup.py#L19)), this means that `torch` must be available during the build, that's not the case by default, and so pip installation fails.
 * bump `huggingface-hub` to use version compatible with `transformers==4.38.1`, otherwise it fails with:
    > RuntimeError: Failed to import transformers.generation.utils because of the following error (look up to see its traceback): cannot import name 'split_torch_state_dict_into_shards' from 'huggingface_hub'

<hr>

The 1st problem has been reported in the original repositories multiple times, including (but not limited to):
 * https://github.com/Dao-AILab/flash-attention/issues/246
 * https://github.com/Dao-AILab/causal-conv1d/issues/2
 * https://github.com/state-spaces/mamba/issues/481

And in this repository, example:
 * https://github.com/kuleshov-group/caduceus/issues/30

The workaround for the 1st problem is to install torch via conda **first** , which gives pip access to it during the build of the problematic packages [^1].

<hr>

I tested the changes in this PR on a fresh Colab VM (T4) and was able to kick off training of the hg38 experiment.

[^1]: for the record, `uv` has a separate mechanism to handle this issue: https://docs.astral.sh/uv/concepts/projects/config/#build-isolation